### PR TITLE
Specify language edition for rustfmt

### DIFF
--- a/.github/workflows/test-course-definition.yml
+++ b/.github/workflows/test-course-definition.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           path: courses/${{github.event.repository.name}}
 
-      - run: find courses/${{github.event.repository.name}} -name '*.rs' | xargs rustfmt --check
+      - run: find courses/${{github.event.repository.name}} -name '*.rs' | xargs rustfmt --edition "2021" --check
 
   identify_language_slugs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently defaulting to the 2015 edition which doesn't understand `async`. Required for to fix buld https://github.com/codecrafters-io/build-your-own-redis/actions/runs/3543856060/jobs/5950660100 on https://github.com/codecrafters-io/build-your-own-redis/pull/53