### PR TITLE
Fix deadlock

### DIFF
--- a/lib/test_harness.rb
+++ b/lib/test_harness.rb
@@ -53,10 +53,16 @@ class TestHarness
     puts ""
 
     stdout_captured, stderr_captured = StringIO.new, StringIO.new
-    setup_io_relay(stdout_io, $stdout, stdout_captured)
-    setup_io_relay(stderr_io, $stderr, stderr_captured)
+    stdout_thread = Thread.new do
+      setup_io_relay(stdout_io, $stdout, stdout_captured)
+    end
+    stderr_thread = Thread.new do
+      setup_io_relay(stderr_io, $stderr, stderr_captured)
+    end
 
     exit_code = wait_thr.value.exitstatus
+    stdout_thread.join
+    stderr_thread.join
     stdout, stderr = stdout_captured.string, stderr_captured.string
 
     puts ""


### PR DESCRIPTION
From the docs
You should be careful to avoid deadlocks. Since pipes are fixed length buffers, Open3.popen3(“prog”) {|i, o, e, t| o.read } deadlocks if the program generates too much output on stderr. You should read stdout and stderr simultaneously (using threads or IO.select)

This was triggering in case of haskell as stack was outputting a lot of logs potentailly overwhelming the buffers.

This also has an added benefit of streaming logs which was not happening before.

I don't do ruby so I don't know what the best practices are this is just a simple solution that fixes the issue. Let me know if you can get this merged or if this requires changes.